### PR TITLE
fix date format on most read section at index page

### DIFF
--- a/app/Models/BlogPost.php
+++ b/app/Models/BlogPost.php
@@ -99,7 +99,7 @@ class BlogPost extends Model implements HasMedia
     public static function popularThisWeek($limit = 6)
     {
         return self::query()
-            ->select('blog_posts.id', 'blog_posts.title', 'blog_posts.slug', DB::raw('COUNT(blog_post_views.id) as views_count'))
+            ->select('blog_posts.id', 'blog_posts.title', 'blog_posts.slug', 'blog_posts.published_at', DB::raw('COUNT(blog_post_views.id) as views_count'))
             ->join('blog_post_views', 'blog_posts.id', '=', 'blog_post_views.blog_post_id')
             ->whereBetween('blog_post_views.created_at', [now()->startOfWeek(), now()->endOfWeek()])
             ->published()

--- a/resources/js/Pages/Index.tsx
+++ b/resources/js/Pages/Index.tsx
@@ -597,11 +597,8 @@ export default function Index({
                                                 <div className="mt-4 flex items-center justify-between text-sm text-gray-500">
                                                     <div className="flex items-center gap-1">
                                                         <Calendar size={14} />
-                                                        {format(
-                                                            new Date(
-                                                                post.published_at,
-                                                            ),
-                                                            'MMM d, yyyy',
+                                                        {formatDate(
+                                                            post.published_at,
                                                         )}
                                                     </div>
                                                     <Link


### PR DESCRIPTION
Fix date formatting bug causing dates to show as Jan 1, 1970 by using `formatDate()` helper.
